### PR TITLE
Fix socket handle not released && upgrade dependencies && cargo clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,18 +10,18 @@ readme      = "README.md"
 repository  = "https://github.com/kentik/netdiag"
 
 [dependencies]
-anyhow      = "1.0.40"
-etherparse  = "0.9.0"
-futures     = "0.3.13"
-libc        = "0.2.92"
+anyhow      = "1.0.52"
+etherparse  = "0.10.1"
+futures     = "0.3.19"
+libc        = "0.2.112"
 log         = "0.4.14"
-parking_lot = "0.11.1"
-rand        = "0.8.3"
+parking_lot = "0.11.2"
+rand        = "0.8.4"
 raw-socket  = "0.0.2"
-socket2     = "0.3.19"
+socket2     = "0.4.2"
 
 [dependencies.tokio]
-version     = "1.4.0"
+version     = "1.15.0"
 features    = ["net"]
 default-features = false
 
@@ -29,5 +29,5 @@ default-features = false
 gumdrop     = "0.8.0"
 
 [dev-dependencies.tokio]
-version     = "1.4.0"
+version     = "1.15.0"
 features    = ["full"]

--- a/src/knock/knock.rs
+++ b/src/knock/knock.rs
@@ -1,22 +1,24 @@
+use super::state::State;
+use super::{probe::Probe, reply::Reply};
+use super::{sock4::Sock4, sock6::Sock6};
+use crate::Bind;
+use anyhow::Result;
+use futures::stream::try_unfold;
+use futures::{Stream, StreamExt};
+use log::error;
+use rand::prelude::*;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use anyhow::Result;
-use futures::{Stream, StreamExt};
-use futures::stream::try_unfold;
-use rand::prelude::*;
+use tokio::sync::broadcast;
 use tokio::sync::mpsc::Receiver;
 use tokio::time::timeout;
-use crate::Bind;
-use super::{probe::Probe, reply::Reply};
-use super::{sock4::Sock4, sock6::Sock6};
-use super::state::State;
 
 #[derive(Debug)]
 pub struct Knock {
-    pub addr:   IpAddr,
-    pub port:   u16,
-    pub count:  usize,
+    pub addr: IpAddr,
+    pub port: u16,
+    pub count: usize,
     pub expiry: Duration,
 }
 
@@ -24,45 +26,64 @@ pub struct Knocker {
     sock4: Sock4,
     sock6: Sock6,
     state: Arc<State>,
+    shutdown: broadcast::Sender<()>,
 }
 
 impl Knocker {
     pub async fn new(bind: &Bind) -> Result<Self> {
         let state = Arc::new(State::new());
+        let (notify_shutdown, _) = broadcast::channel(1);
 
-        let sock4 = Sock4::new(bind, state.clone()).await?;
-        let sock6 = Sock6::new(bind, state.clone()).await?;
+        let sock4 = Sock4::new(bind, state.clone(), notify_shutdown.subscribe()).await?;
+        let sock6 = Sock6::new(bind, state.clone(), notify_shutdown.subscribe()).await?;
 
-        Ok(Self { sock4, sock6, state })
+        Ok(Self {
+            sock4,
+            sock6,
+            state,
+            shutdown: notify_shutdown,
+        })
     }
 
-    pub async fn knock(&self, knock: &Knock) -> Result<impl Stream<Item = Result<Option<Duration>>> + '_> {
-        let Knock { addr, port, count, expiry } = *knock;
+    pub async fn knock(
+        &self,
+        knock: &Knock,
+    ) -> Result<impl Stream<Item = Result<Option<Duration>>> + '_> {
+        let Knock {
+            addr,
+            port,
+            count,
+            expiry,
+        } = *knock;
 
         let dst = SocketAddr::new(addr, port);
         let src = self.source(addr, port).await?;
         let (src, rx) = self.state.reserve(src, dst).await;
 
         Ok(try_unfold((src, rx), move |(src, mut rx)| async move {
-            let seq   = random();
+            let seq = random();
             let probe = Probe::new(*src, dst, seq)?;
-            let rtt   = self.probe(&probe, &mut rx, expiry).await?;
+            let rtt = self.probe(&probe, &mut rx, expiry).await?;
             Ok(Some((rtt, (src, rx))))
-        }).take(count))
+        })
+        .take(count))
     }
 
-    async fn probe(&self, probe: &Probe, rx: &mut Receiver<Reply>, expiry: Duration) -> Result<Option<Duration>> {
+    async fn probe(
+        &self,
+        probe: &Probe,
+        rx: &mut Receiver<Reply>,
+        expiry: Duration,
+    ) -> Result<Option<Duration>> {
         let mut retries = 1;
 
         while retries > 0 {
-            let sent  = self.send(probe).await?;
+            let sent = self.send(probe).await?;
             let reply = timeout(expiry, rx.recv());
 
             if let Ok(Some(Reply { head, when })) = reply.await {
-                if head.syn && head.ack {
-                    if head.acknowledgment_number == probe.seq() + 1 {
-                        return Ok(Some(when.saturating_duration_since(sent)))
-                    }
+                if head.syn && head.ack && head.acknowledgment_number == probe.seq() + 1 {
+                    return Ok(Some(when.saturating_duration_since(sent)));
                 }
             }
 
@@ -83,6 +104,14 @@ impl Knocker {
         match dst {
             IpAddr::V4(..) => self.sock4.source(dst, port).await,
             IpAddr::V6(..) => self.sock6.source(dst, port).await,
+        }
+    }
+}
+
+impl Drop for Knocker {
+    fn drop(&mut self) {
+        if let Err(e) = self.shutdown.send(()) {
+            error!("background task shutdown failed: {}", e);
         }
     }
 }

--- a/src/knock/sock6.rs
+++ b/src/knock/sock6.rs
@@ -1,28 +1,33 @@
-use std::io::IoSliceMut;
-use std::net::{IpAddr, SocketAddr};
-use std::time::Instant;
-use std::sync::Arc;
+use super::state::State;
+use super::{probe::ProbeV6, reply::Reply};
+use crate::{Bind, RouteSocket};
 use anyhow::Result;
 use etherparse::TcpHeader;
-use libc::{IPPROTO_TCP, c_int};
+use libc::{c_int, IPPROTO_TCP};
 use log::{debug, error};
 use raw_socket::tokio::prelude::*;
+use std::io::IoSliceMut;
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
+use std::time::Instant;
+use tokio::sync::broadcast;
 use tokio::sync::Mutex;
-use crate::{Bind, RouteSocket};
-use super::{probe::ProbeV6, reply::Reply};
-use super::state::State;
 
 pub struct Sock6 {
-    sock:  Mutex<Arc<RawSocket>>,
+    sock: Mutex<Arc<RawSocket>>,
     route: Mutex<RouteSocket>,
 }
 
 impl Sock6 {
-    pub async fn new(bind: &Bind, state: Arc<State>) -> Result<Self> {
+    pub async fn new(
+        bind: &Bind,
+        state: Arc<State>,
+        shutdown: broadcast::Receiver<()>,
+    ) -> Result<Self> {
         let ipv6 = Domain::ipv6();
-        let tcp  = Protocol::from(IPPROTO_TCP);
+        let tcp = Protocol::from(IPPROTO_TCP);
 
-        let sock  = Arc::new(RawSocket::new(ipv6, Type::raw(), Some(tcp))?);
+        let sock = Arc::new(RawSocket::new(ipv6, Type::raw(), Some(tcp))?);
         let route = RouteSocket::new(bind.sa6()).await?;
 
         sock.bind(bind.sa6()).await?;
@@ -34,14 +39,14 @@ impl Sock6 {
         let rx = sock.clone();
 
         tokio::spawn(async move {
-            match recv(rx, state).await {
+            match recv(rx, state, shutdown).await {
                 Ok(()) => debug!("recv finished"),
                 Err(e) => error!("recv failed: {}", e),
             }
         });
 
         Ok(Self {
-            sock:  Mutex::new(sock),
+            sock: Mutex::new(sock),
             route: Mutex::new(route),
         })
     }
@@ -55,7 +60,7 @@ impl Sock6 {
         let dst = SocketAddr::V6(dst);
 
         let sock = self.sock.lock().await;
-        sock.send_to(&pkt, &dst).await?;
+        sock.send_to(pkt, &dst).await?;
 
         Ok(Instant::now())
     }
@@ -66,33 +71,43 @@ impl Sock6 {
     }
 }
 
-async fn recv(sock: Arc<RawSocket>, state: Arc<State>) -> Result<()> {
+async fn recv(
+    sock: Arc<RawSocket>,
+    state: Arc<State>,
+    mut shutdown: broadcast::Receiver<()>,
+) -> Result<()> {
     let mut pkt = [0u8; 64];
     let mut ctl = [0u8; 64];
 
     loop {
         let iovec = &[IoSliceMut::new(&mut pkt)];
-        let (n, src) = sock.recv_msg(iovec, Some(&mut ctl)).await?;
 
-        let now = Instant::now();
-        let pkt = TcpHeader::read_from_slice(&pkt[..n]);
-        let dst = CMsg::decode(&ctl).find_map(|msg| {
-            match msg {
-                CMsg::Ipv6PktInfo(info) => Some(info.addr().into()),
-                _                       => None,
-            }
-        });
+        tokio::select! {
+            result = sock.recv_msg(iovec, Some(&mut ctl)) => {
+                let (n, src) = result?;
 
-        if let (Ok((head, _tail)), Some(dst)) = (pkt, dst) {
-            let src = SocketAddr::new(src.ip(), head.source_port);
-            let dst = SocketAddr::new(dst, head.destination_port);
+                let now = Instant::now();
+                let pkt = TcpHeader::from_slice(&pkt[..n]);
+                let dst = CMsg::decode(&ctl).find_map(|msg| match msg {
+                    CMsg::Ipv6PktInfo(info) => Some(info.addr().into()),
+                    _ => None,
+                });
 
-            if let Some(tx) = state.sender(dst, src) {
-                match tx.send(Reply::new(head, now)).await {
-                    Ok(()) => (),
-                    Err(_) => (),
+                if let (Ok((head, _tail)), Some(dst)) = (pkt, dst) {
+                    let src = SocketAddr::new(src.ip(), head.source_port);
+                    let dst = SocketAddr::new(dst, head.destination_port);
+
+                    if let Some(tx) = state.sender(dst, src) {
+                        if let Err(e) = tx.send(Reply::new(head, now)).await {
+                            error!("{}", e);
+                        }
+                    }
                 }
+            }
+            _ = shutdown.recv() => {
+                break;
             }
         }
     }
+    Ok(())
 }

--- a/src/ping/sock4.rs
+++ b/src/ping/sock4.rs
@@ -1,26 +1,30 @@
+use super::probe::Probe;
+use super::state::State;
+use crate::icmp::icmp4::checksum;
+use crate::icmp::IcmpV4Packet;
+use crate::Bind;
+use anyhow::Result;
+use etherparse::{IpNumber, Ipv4Header};
+use log::{debug, error};
+use raw_socket::tokio::RawSocket;
+use raw_socket::{Domain, Protocol, Type};
 use std::convert::{TryFrom, TryInto};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Instant;
-use anyhow::Result;
-use etherparse::{Ipv4Header, IpTrafficClass};
-use log::{debug, error};
-use raw_socket::{Domain, Type, Protocol};
-use raw_socket::tokio::RawSocket;
-use tokio::sync::Mutex;
-use crate::Bind;
-use crate::icmp::IcmpV4Packet;
-use crate::icmp::icmp4::checksum;
-use super::probe::Probe;
-use super::state::State;
+use tokio::sync::{broadcast, Mutex};
 
 pub struct Sock4 {
-    sock: Mutex<Arc<RawSocket>>
+    sock: Mutex<Arc<RawSocket>>,
 }
 
 impl Sock4 {
-    pub async fn new(bind: &Bind, state: Arc<State>) -> Result<Self> {
-        let raw   = Type::raw();
+    pub async fn new(
+        bind: &Bind,
+        state: Arc<State>,
+        notify: broadcast::Receiver<()>,
+    ) -> Result<Self> {
+        let raw = Type::raw();
         let icmp4 = Protocol::icmpv4();
 
         let sock = Arc::new(RawSocket::new(Domain::ipv4(), raw, Some(icmp4))?);
@@ -28,48 +32,62 @@ impl Sock4 {
         let rx = sock.clone();
 
         tokio::spawn(async move {
-            match recv(rx, state).await {
+            match recv(rx, state, notify).await {
                 Ok(()) => debug!("recv finished"),
                 Err(e) => error!("recv failed: {}", e),
             }
         });
 
-        Ok(Self { sock: Mutex::new(sock) })
+        Ok(Self {
+            sock: Mutex::new(sock),
+        })
     }
 
     pub async fn send(&self, probe: &Probe) -> Result<Instant> {
         let mut pkt = [0u8; 64];
 
         let pkt = probe.encode(&mut pkt)?;
-        let cksum = checksum(&pkt).to_be_bytes();
+        let cksum = checksum(pkt).to_be_bytes();
         pkt[2..4].copy_from_slice(&cksum);
 
         let addr = SocketAddr::new(probe.addr, 0);
         let sock = self.sock.lock().await;
-        sock.send_to(&pkt, &addr).await?;
+        sock.send_to(pkt, &addr).await?;
 
         Ok(Instant::now())
     }
 }
 
-async fn recv(sock: Arc<RawSocket>, state: Arc<State>) -> Result<()> {
+async fn recv(
+    sock: Arc<RawSocket>,
+    state: Arc<State>,
+    mut shutdown: broadcast::Receiver<()>,
+) -> Result<()> {
     let mut pkt = [0u8; 128];
     loop {
-        let (n, _) = sock.recv_from(&mut pkt).await?;
+        tokio::select! {
+            result = sock.recv_from(&mut pkt) => {
+                let (n, _) = result?;
 
-        let now = Instant::now();
-        let pkt = Ipv4Header::read_from_slice(&pkt[..n])?;
+                let now = Instant::now();
+                let pkt = Ipv4Header::from_slice(&pkt[..n])?;
 
-        if let (Ipv4Header { protocol: ICMP4, .. }, tail) = pkt {
-            if let IcmpV4Packet::EchoReply(echo) = IcmpV4Packet::try_from(tail)? {
-                if let Ok(token) = echo.data.try_into() {
-                    if let Some(tx) = state.remove(&token) {
-                        let _ = tx.send(now);
+                if let (Ipv4Header { protocol: ICMP4, .. }, tail) = pkt {
+                    if let IcmpV4Packet::EchoReply(echo) = IcmpV4Packet::try_from(tail)? {
+                        if let Ok(token) = echo.data.try_into() {
+                            if let Some(tx) = state.remove(&token) {
+                                let _ = tx.send(now);
+                            }
+                        }
                     }
                 }
             }
+            _ = shutdown.recv() => {
+                break;
+            }
         }
     }
+    Ok(())
 }
 
-const ICMP4: u8 = IpTrafficClass::Icmp as u8;
+const ICMP4: u8 = IpNumber::Icmp as u8;

--- a/src/ping/sock6.rs
+++ b/src/ping/sock6.rs
@@ -1,24 +1,28 @@
-use std::convert::{TryFrom, TryInto};
-use std::net::SocketAddr;
-use std::sync::Arc;
-use std::time::Instant;
 use anyhow::Result;
 use log::{debug, error};
-use raw_socket::{Domain, Type, Protocol};
-use raw_socket::tokio::RawSocket;
-use tokio::sync::Mutex;
-use crate::Bind;
-use crate::icmp::IcmpV6Packet;
-use super::probe::Probe;
-use super::state::State;
+use raw_socket::{tokio::RawSocket, Domain, Protocol, Type};
+use std::{
+    convert::{TryFrom, TryInto},
+    net::SocketAddr,
+    sync::Arc,
+    time::Instant,
+};
+use tokio::sync::{broadcast, Mutex};
+
+use super::{probe::Probe, state::State};
+use crate::{icmp::IcmpV6Packet, Bind};
 
 pub struct Sock6 {
-    sock: Mutex<Arc<RawSocket>>
+    sock: Mutex<Arc<RawSocket>>,
 }
 
 impl Sock6 {
-    pub async fn new(bind: &Bind, state: Arc<State>) -> Result<Self> {
-        let raw   = Type::raw();
+    pub async fn new(
+        bind: &Bind,
+        state: Arc<State>,
+        notify: broadcast::Receiver<()>,
+    ) -> Result<Self> {
+        let raw = Type::raw();
         let icmp6 = Protocol::icmpv6();
 
         let sock = Arc::new(RawSocket::new(Domain::ipv6(), raw, Some(icmp6))?);
@@ -26,41 +30,55 @@ impl Sock6 {
         let rx = sock.clone();
 
         tokio::spawn(async move {
-            match recv(rx, state).await {
+            match recv(rx, state, notify).await {
                 Ok(()) => debug!("recv finished"),
                 Err(e) => error!("recv failed: {}", e),
             }
         });
 
-        Ok(Self { sock: Mutex::new(sock) })
+        Ok(Self {
+            sock: Mutex::new(sock),
+        })
     }
 
     pub async fn send(&self, probe: &Probe) -> Result<Instant> {
         let mut pkt = [0u8; 64];
 
-        let pkt  = probe.encode(&mut pkt)?;
+        let pkt = probe.encode(&mut pkt)?;
         let addr = SocketAddr::new(probe.addr, 0);
         let sock = self.sock.lock().await;
-        sock.send_to(&pkt, &addr).await?;
+        sock.send_to(pkt, &addr).await?;
 
         Ok(Instant::now())
     }
 }
 
-async fn recv(sock: Arc<RawSocket>, state: Arc<State>) -> Result<()> {
+async fn recv(
+    sock: Arc<RawSocket>,
+    state: Arc<State>,
+    mut shutdown: broadcast::Receiver<()>,
+) -> Result<()> {
     let mut pkt = [0u8; 64];
     loop {
-        let (n, _) = sock.recv_from(&mut pkt).await?;
+        tokio::select! {
+            result = sock.recv_from(&mut pkt) => {
+                let (n, _) = result?;
 
-        let now = Instant::now();
-        let pkt = IcmpV6Packet::try_from(&pkt[..n])?;
+                let now = Instant::now();
+                let pkt = IcmpV6Packet::try_from(&pkt[..n])?;
 
-        if let IcmpV6Packet::EchoReply(echo) = pkt {
-            if let Ok(token) = echo.data.try_into() {
-                if let Some(tx) = state.remove(&token) {
-                    let _ = tx.send(now);
+                if let IcmpV6Packet::EchoReply(echo) = pkt {
+                    if let Ok(token) = echo.data.try_into() {
+                        if let Some(tx) = state.remove(&token) {
+                            let _ = tx.send(now);
+                        }
+                    }
                 }
+            }
+            _ = shutdown.recv() => {
+                break;
             }
         }
     }
+    Ok(())
 }

--- a/src/trace/icmp.rs
+++ b/src/trace/icmp.rs
@@ -1,22 +1,22 @@
+use super::probe::{Key, Probe};
+use super::reply::Echo;
+use super::state::State;
+use crate::icmp::{icmp4, icmp6, IcmpV4Packet, IcmpV6Packet};
+use crate::Bind;
+use anyhow::Result;
+use etherparse::{IpNumber, Ipv4Header};
+use libc::c_int;
+use log::{debug, error};
+use raw_socket::tokio::prelude::*;
 use std::convert::TryFrom;
 use std::future::Future;
 use std::io::IoSliceMut;
 use std::sync::Arc;
 use std::time::Instant;
-use anyhow::Result;
-use etherparse::{IpTrafficClass, Ipv4Header};
-use libc::c_int;
-use log::{debug, error};
-use raw_socket::tokio::prelude::*;
-use crate::Bind;
-use crate::icmp::{icmp4, icmp6, IcmpV4Packet, IcmpV6Packet};
-use super::probe::{Key, Probe};
-use super::reply::Echo;
-use super::state::State;
 
 pub async fn exec(bind: &Bind, state: &Arc<State>) -> Result<(Arc<RawSocket>, Arc<RawSocket>)> {
-    let ipv4  = Domain::ipv4();
-    let ipv6  = Domain::ipv6();
+    let ipv4 = Domain::ipv4();
+    let ipv6 = Domain::ipv6();
     let icmp4 = Protocol::icmpv4();
     let icmp6 = Protocol::icmpv6();
 
@@ -27,7 +27,7 @@ pub async fn exec(bind: &Bind, state: &Arc<State>) -> Result<(Arc<RawSocket>, Ar
     icmp6.bind(bind.sa6()).await?;
 
     let enable: c_int = 1;
-    icmp4.set_sockopt(Level::IPV4, Name::IPV4_HDRINCL,     &enable)?;
+    icmp4.set_sockopt(Level::IPV4, Name::IPV4_HDRINCL, &enable)?;
     icmp6.set_sockopt(Level::IPV6, Name::IPV6_RECVPKTINFO, &enable)?;
 
     spawn("recv4", recv4(icmp4.clone(), state.clone()));
@@ -42,7 +42,7 @@ async fn recv4(sock: Arc<RawSocket>, state: Arc<State>) -> Result<()> {
         let (n, from) = sock.recv_from(&mut pkt).await?;
 
         let now = Instant::now();
-        let pkt = Ipv4Header::read_from_slice(&pkt[..n])?;
+        let pkt = Ipv4Header::from_slice(&pkt[..n])?;
 
         if let (ip @ Ipv4Header { protocol: ICMP, .. }, tail) = pkt {
             let icmp = IcmpV4Packet::try_from(tail)?;
@@ -55,10 +55,10 @@ async fn recv4(sock: Arc<RawSocket>, state: Arc<State>) -> Result<()> {
                 }
             } else if let IcmpV4Packet::Unreachable(what) = icmp {
                 let pkt = match what {
-                    icmp4::Unreachable::Net(pkt)      => pkt,
-                    icmp4::Unreachable::Host(pkt)     => pkt,
+                    icmp4::Unreachable::Net(pkt) => pkt,
+                    icmp4::Unreachable::Host(pkt) => pkt,
                     icmp4::Unreachable::Protocol(pkt) => pkt,
-                    icmp4::Unreachable::Port(pkt)     => pkt,
+                    icmp4::Unreachable::Port(pkt) => pkt,
                     icmp4::Unreachable::Other(_, pkt) => pkt,
                 };
 
@@ -99,8 +99,8 @@ async fn recv6(sock: Arc<RawSocket>, state: Arc<State>) -> Result<()> {
             }
         } else if let IcmpV6Packet::Unreachable(what) = pkt {
             let pkt = match what {
-                icmp6::Unreachable::Address(pkt)  => pkt,
-                icmp6::Unreachable::Port(pkt)     => pkt,
+                icmp6::Unreachable::Address(pkt) => pkt,
+                icmp6::Unreachable::Port(pkt) => pkt,
                 icmp6::Unreachable::Other(_, pkt) => pkt,
             };
 
@@ -110,11 +110,9 @@ async fn recv6(sock: Arc<RawSocket>, state: Arc<State>) -> Result<()> {
                 }
             }
         } else if let IcmpV6Packet::EchoReply(echo) = pkt {
-            let dst = CMsg::decode(&ctl).find_map(|msg| {
-                match msg {
-                    CMsg::Ipv6PktInfo(info) => Some(info.addr()),
-                    _                       => None,
-                }
+            let dst = CMsg::decode(&ctl).find_map(|msg| match msg {
+                CMsg::Ipv6PktInfo(info) => Some(info.addr()),
+                _ => None,
             });
 
             if let Some(dst) = dst {
@@ -138,4 +136,4 @@ fn spawn<F: Future<Output = Result<()>> + Send + 'static>(name: &'static str, fu
     });
 }
 
-const ICMP: u8 = IpTrafficClass::Icmp as u8;
+const ICMP: u8 = IpNumber::Icmp as u8;

--- a/src/trace/probe/icmp.rs
+++ b/src/trace/probe/icmp.rs
@@ -1,16 +1,16 @@
+use super::{Key, Probe};
+use crate::icmp::{icmp4, icmp6};
+use anyhow::{anyhow, Result};
+use etherparse::*;
 use std::convert::{TryFrom, TryInto};
 use std::io::{Cursor, Write};
 use std::net::{Ipv4Addr, Ipv6Addr};
-use anyhow::{Result, anyhow};
-use etherparse::*;
-use crate::icmp::{icmp4, icmp6};
-use super::{Key, Probe};
 
 #[derive(Debug)]
 pub struct ICMPv4 {
     pub src: Ipv4Addr,
     pub dst: Ipv4Addr,
-    pub id:  u16,
+    pub id: u16,
     pub seq: u16,
 }
 
@@ -18,7 +18,7 @@ pub struct ICMPv4 {
 pub struct ICMPv6 {
     pub src: Ipv6Addr,
     pub dst: Ipv6Addr,
-    pub id:  u16,
+    pub id: u16,
     pub seq: u16,
 }
 
@@ -35,7 +35,7 @@ impl ICMPv4 {
             return Err(anyhow!("short buffer"));
         }
 
-        let id  = u16::from_be_bytes(tail[4..6].try_into()?);
+        let id = u16::from_be_bytes(tail[4..6].try_into()?);
         let seq = u16::from_be_bytes(tail[6..8].try_into()?);
 
         Ok(Probe::from(ICMPv4 { src, dst, id, seq }))
@@ -48,7 +48,7 @@ impl ICMPv4 {
         let dst = self.dst.octets();
         let len = u16::try_from(icmp4::HEADER_SIZE)?;
 
-        let pkt = Ipv4Header::new(len, ttl, IpTrafficClass::Icmp, src, dst);
+        let pkt = Ipv4Header::new(len, ttl, IpNumber::Icmp, src, dst);
         pkt.write(&mut buf)?;
 
         let mut pkt = [0u8; icmp4::HEADER_SIZE];
@@ -90,7 +90,7 @@ impl ICMPv6 {
             return Err(anyhow!("short buffer"));
         }
 
-        let id  = u16::from_be_bytes(tail[4..6].try_into()?);
+        let id = u16::from_be_bytes(tail[4..6].try_into()?);
         let seq = u16::from_be_bytes(tail[6..8].try_into()?);
 
         Ok(Probe::from(ICMPv6 { src, dst, id, seq }))

--- a/src/trace/probe/probe.rs
+++ b/src/trace/probe/probe.rs
@@ -1,8 +1,8 @@
+use super::{ICMPv4, ICMPv6, TCPv4, TCPv6, UDPv4, UDPv6};
+use anyhow::{anyhow, Error, Result};
+use etherparse::{IpNumber, Ipv4Header, Ipv6Header};
 use std::convert::TryFrom;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
-use anyhow::{anyhow, Error, Result};
-use etherparse::{IpTrafficClass, Ipv4Header, Ipv6Header};
-use super::{ICMPv4, ICMPv6, TCPv4, TCPv6, UDPv4, UDPv6};
 
 #[derive(Debug)]
 pub enum Probe {
@@ -39,14 +39,15 @@ pub enum Protocol {
 #[derive(Debug)]
 pub struct Probes {
     proto: Protocol,
-    src:   SocketAddr,
-    dst:   IpAddr,
+    src: SocketAddr,
+    dst: IpAddr,
     value: u16,
 }
 
 pub const PORT_MIN: u16 = 33434;
 pub const PORT_MAX: u16 = 65407;
 
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub enum Key {
     ICMP(IpAddr, IpAddr, u16),
@@ -56,21 +57,21 @@ pub enum Key {
 
 impl Probe {
     pub fn decode4(pkt: &[u8]) -> Result<Key> {
-        let (head, tail) = Ipv4Header::read_from_slice(pkt)?;
+        let (head, tail) = Ipv4Header::from_slice(pkt)?;
         match head.protocol {
             ICMP4 => Ok(ICMPv4::decode(head, tail)?.key()),
-            TCP   => Ok(TCPv4::decode(head, tail)?.key()),
-            UDP   => Ok(UDPv4::decode(head, tail)?.key()),
+            TCP => Ok(TCPv4::decode(head, tail)?.key()),
+            UDP => Ok(UDPv4::decode(head, tail)?.key()),
             other => Err(anyhow!("unsupported protocol: {}", other)),
         }
     }
 
     pub fn decode6(pkt: &[u8]) -> Result<Key> {
-        let (head, tail) = Ipv6Header::read_from_slice(pkt)?;
+        let (head, tail) = Ipv6Header::from_slice(pkt)?;
         match head.next_header {
             ICMP6 => Ok(ICMPv6::decode(head, tail)?.key()),
-            TCP   => Ok(TCPv6::decode(head, tail)?.key()),
-            UDP   => Ok(UDPv6::decode(head, tail)?.key()),
+            TCP => Ok(TCPv6::decode(head, tail)?.key()),
+            UDP => Ok(UDPv6::decode(head, tail)?.key()),
             other => Err(anyhow!("unsupported protocol: {}", other)),
         }
     }
@@ -79,10 +80,10 @@ impl Probe {
         match self {
             Self::ICMP(ICMP::V4(v4)) => v4.encode(buf, ttl),
             Self::ICMP(ICMP::V6(v6)) => v6.encode(buf),
-            Self::TCP(TCP::V4(v4))   => v4.encode(buf, ttl),
-            Self::TCP(TCP::V6(v6))   => v6.encode(buf),
-            Self::UDP(UDP::V4(v4))   => v4.encode(buf, ttl),
-            Self::UDP(UDP::V6(v6))   => v6.encode(buf),
+            Self::TCP(TCP::V4(v4)) => v4.encode(buf, ttl),
+            Self::TCP(TCP::V6(v6)) => v6.encode(buf),
+            Self::UDP(UDP::V4(v4)) => v4.encode(buf, ttl),
+            Self::UDP(UDP::V6(v6)) => v6.encode(buf),
         }
     }
 
@@ -90,10 +91,10 @@ impl Probe {
         match self {
             Self::ICMP(ICMP::V4(v4)) => SocketAddr::new(v4.dst.into(), 0),
             Self::ICMP(ICMP::V6(v6)) => SocketAddr::new(v6.dst.into(), 0),
-            Self::TCP(TCP::V4(v4))   => v4.dst.into(),
-            Self::TCP(TCP::V6(v6))   => v6.dst.into(),
-            Self::UDP(UDP::V4(v4))   => v4.dst.into(),
-            Self::UDP(UDP::V6(v6))   => v6.dst.into(),
+            Self::TCP(TCP::V4(v4)) => v4.dst.into(),
+            Self::TCP(TCP::V6(v6)) => v6.dst.into(),
+            Self::UDP(UDP::V4(v4)) => v4.dst.into(),
+            Self::UDP(UDP::V6(v6)) => v6.dst.into(),
         }
     }
 
@@ -101,10 +102,10 @@ impl Probe {
         match self {
             Self::ICMP(ICMP::V4(v4)) => Key::ICMP(v4.src.into(), IpAddr::from(v4.dst), v4.id),
             Self::ICMP(ICMP::V6(v6)) => Key::ICMP(v6.src.into(), IpAddr::from(v6.dst), v6.id),
-            Self::TCP(TCP::V4(v4))   => Key::TCP(v4.src.into(), IpAddr::from(*v4.dst.ip())),
-            Self::TCP(TCP::V6(v6))   => Key::TCP(v6.src.into(), IpAddr::from(*v6.dst.ip())),
-            Self::UDP(UDP::V4(v4))   => Key::UDP(v4.src.into(), IpAddr::from(*v4.dst.ip())),
-            Self::UDP(UDP::V6(v6))   => Key::UDP(v6.src.into(), IpAddr::from(*v6.dst.ip())),
+            Self::TCP(TCP::V4(v4)) => Key::TCP(v4.src.into(), IpAddr::from(*v4.dst.ip())),
+            Self::TCP(TCP::V6(v6)) => Key::TCP(v6.src.into(), IpAddr::from(*v6.dst.ip())),
+            Self::UDP(UDP::V4(v4)) => Key::UDP(v4.src.into(), IpAddr::from(*v4.dst.ip())),
+            Self::UDP(UDP::V6(v6)) => Key::UDP(v6.src.into(), IpAddr::from(*v6.dst.ip())),
         }
     }
 
@@ -112,10 +113,10 @@ impl Probe {
         match self {
             Self::ICMP(ICMP::V4(v4)) => v4.increment(),
             Self::ICMP(ICMP::V6(v6)) => v6.increment(),
-            Self::TCP(TCP::V4(v4))   => v4.increment(),
-            Self::TCP(TCP::V6(v6))   => v6.increment(),
-            Self::UDP(UDP::V4(v4))   => v4.increment(),
-            Self::UDP(UDP::V6(v6))   => v6.increment(),
+            Self::TCP(TCP::V4(v4)) => v4.increment(),
+            Self::TCP(TCP::V6(v6)) => v6.increment(),
+            Self::UDP(UDP::V4(v4)) => v4.increment(),
+            Self::UDP(UDP::V6(v6)) => v6.increment(),
         }
     }
 }
@@ -123,26 +124,41 @@ impl Probe {
 impl Probes {
     pub fn new(proto: Protocol, src: IpAddr, dst: IpAddr, value: u16) -> Self {
         let src = match proto {
-            Protocol::ICMP    => SocketAddr::new(src, 0),
+            Protocol::ICMP => SocketAddr::new(src, 0),
             Protocol::TCP(..) => SocketAddr::new(src, value),
             Protocol::UDP(..) => SocketAddr::new(src, value),
         };
-        Self { proto, src, dst, value }
+        Self {
+            proto,
+            src,
+            dst,
+            value,
+        }
     }
 
     pub fn key(&self) -> Key {
-        let Self { proto, src, dst, value } = *self;
+        let Self {
+            proto,
+            src,
+            dst,
+            value,
+        } = *self;
         match proto {
-            Protocol::ICMP    => Key::ICMP(src.ip(), dst, value),
+            Protocol::ICMP => Key::ICMP(src.ip(), dst, value),
             Protocol::TCP(..) => Key::TCP(src, dst),
             Protocol::UDP(..) => Key::UDP(src, dst),
         }
     }
 
     pub fn probe(&self) -> Result<Probe> {
-        let Self { proto, src, dst, value } = *self;
+        let Self {
+            proto,
+            src,
+            dst,
+            value,
+        } = *self;
         Ok(match proto {
-            Protocol::ICMP      => Probe::ICMP(ICMP::try_from((src, dst, value))?),
+            Protocol::ICMP => Probe::ICMP(ICMP::try_from((src, dst, value))?),
             Protocol::TCP(port) => Probe::TCP(TCP::try_from((src, dst, port))?),
             Protocol::UDP(port) => Probe::UDP(UDP::try_from((src, dst, port))?),
         })
@@ -196,9 +212,13 @@ impl TryFrom<(SocketAddr, IpAddr, u16)> for ICMP {
 
     fn try_from((src, dst, id): (SocketAddr, IpAddr, u16)) -> Result<Self, Self::Error> {
         match (src, dst) {
-            (SocketAddr::V4(src), IpAddr::V4(dst)) => Ok(ICMP::V4(ICMPv4::new(*src.ip(), dst, id, 0))),
-            (SocketAddr::V6(src), IpAddr::V6(dst)) => Ok(ICMP::V6(ICMPv6::new(*src.ip(), dst, id, 0))),
-            _                                      => Err(invalid()),
+            (SocketAddr::V4(src), IpAddr::V4(dst)) => {
+                Ok(ICMP::V4(ICMPv4::new(*src.ip(), dst, id, 0)))
+            }
+            (SocketAddr::V6(src), IpAddr::V6(dst)) => {
+                Ok(ICMP::V6(ICMPv6::new(*src.ip(), dst, id, 0)))
+            }
+            _ => Err(invalid()),
         }
     }
 }
@@ -210,7 +230,7 @@ impl TryFrom<(SocketAddr, IpAddr, u16)> for TCP {
         match (src, dst) {
             (SocketAddr::V4(src), IpAddr::V4(dst)) => Ok(TCP::V4(TCPv4::new(src, sa4(dst, port)))),
             (SocketAddr::V6(src), IpAddr::V6(dst)) => Ok(TCP::V6(TCPv6::new(src, sa6(dst, port)))),
-            _                                      => Err(invalid()),
+            _ => Err(invalid()),
         }
     }
 }
@@ -222,7 +242,7 @@ impl TryFrom<(SocketAddr, IpAddr, u16)> for UDP {
         match (src, dst) {
             (SocketAddr::V4(src), IpAddr::V4(dst)) => Ok(UDP::V4(UDPv4::new(src, sa4(dst, port)))),
             (SocketAddr::V6(src), IpAddr::V6(dst)) => Ok(UDP::V6(UDPv6::new(src, sa6(dst, port)))),
-            _                                      => Err(invalid()),
+            _ => Err(invalid()),
         }
     }
 }
@@ -239,7 +259,7 @@ fn invalid() -> Error {
     anyhow!("mixed IPv4 and IPv6 addresses")
 }
 
-const ICMP4: u8 = IpTrafficClass::Icmp     as u8;
-const ICMP6: u8 = IpTrafficClass::IPv6Icmp as u8;
-const TCP:   u8 = IpTrafficClass::Tcp      as u8;
-const UDP:   u8 = IpTrafficClass::Udp      as u8;
+const ICMP4: u8 = IpNumber::Icmp as u8;
+const ICMP6: u8 = IpNumber::IPv6Icmp as u8;
+const TCP: u8 = IpNumber::Tcp as u8;
+const UDP: u8 = IpNumber::Udp as u8;

--- a/src/trace/probe/udp.rs
+++ b/src/trace/probe/udp.rs
@@ -1,8 +1,8 @@
-use std::io::Cursor;
-use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
+use super::Probe;
 use anyhow::Result;
 use etherparse::*;
-use super::Probe;
+use std::io::Cursor;
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
 
 #[derive(Debug)]
 pub struct UDPv4 {
@@ -25,7 +25,7 @@ impl UDPv4 {
         let src = Ipv4Addr::from(ip.source);
         let dst = Ipv4Addr::from(ip.destination);
 
-        let pkt = UdpHeaderSlice::from_slice(&tail)?;
+        let pkt = UdpHeaderSlice::from_slice(tail)?;
         let src = SocketAddrV4::new(src, pkt.source_port());
         let dst = SocketAddrV4::new(dst, pkt.destination_port());
 
@@ -61,7 +61,7 @@ impl UDPv6 {
         let src = Ipv6Addr::from(ip.source);
         let dst = Ipv6Addr::from(ip.destination);
 
-        let pkt = UdpHeaderSlice::from_slice(&tail)?;
+        let pkt = UdpHeaderSlice::from_slice(tail)?;
         let src = SocketAddrV6::new(src, pkt.source_port(), 0, 0);
         let dst = SocketAddrV6::new(dst, pkt.destination_port(), 0, 0);
 

--- a/src/trace/trace.rs
+++ b/src/trace/trace.rs
@@ -1,24 +1,26 @@
+use super::icmp;
+use super::probe::{Probe, Protocol, ICMP, TCP, UDP};
+use super::reply::{Echo, Node};
+use super::state::{Lease, State};
+use super::{sock4::Sock4, sock6::Sock6};
+use crate::Bind;
+use anyhow::Result;
+use futures::future;
+use futures::stream::try_unfold;
+use futures::{Stream, StreamExt, TryStreamExt};
+use log::error;
 use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use anyhow::Result;
-use futures::future;
-use futures::{Stream, StreamExt, TryStreamExt};
-use futures::stream::try_unfold;
+use tokio::sync::broadcast;
 use tokio::time::timeout;
-use crate::Bind;
-use super::probe::{Probe, Protocol, ICMP, TCP, UDP};
-use super::reply::{Echo, Node};
-use super::{sock4::Sock4, sock6::Sock6};
-use super::state::{Lease, State};
-use super::icmp;
 
 #[derive(Debug)]
 pub struct Trace {
-    pub proto:  Protocol,
-    pub addr:   IpAddr,
+    pub proto: Protocol,
+    pub addr: IpAddr,
     pub probes: usize,
-    pub limit:  usize,
+    pub limit: usize,
     pub expiry: Duration,
 }
 
@@ -26,45 +28,62 @@ pub struct Tracer {
     sock4: Sock4,
     sock6: Sock6,
     state: Arc<State>,
+    shutdown: broadcast::Sender<()>,
 }
 
 impl Tracer {
     pub async fn new(bind: &Bind) -> Result<Self> {
         let state = Arc::new(State::new());
 
-        let (icmp4, icmp6) = icmp::exec(bind, &state).await?;
-        let sock4 = Sock4::new(bind, icmp4, state.clone()).await?;
-        let sock6 = Sock6::new(bind, icmp6, state.clone()).await?;
+        let (notify_shutdown, _) = broadcast::channel(1);
 
-        Ok(Self { sock4, sock6, state })
+        let (icmp4, icmp6) = icmp::exec(bind, &state).await?;
+        let sock4 = Sock4::new(bind, icmp4, state.clone(), notify_shutdown.subscribe()).await?;
+        let sock6 = Sock6::new(bind, icmp6, state.clone(), notify_shutdown.subscribe()).await?;
+
+        Ok(Self {
+            sock4,
+            sock6,
+            state,
+            shutdown: notify_shutdown,
+        })
     }
 
     pub async fn route(&self, trace: Trace) -> Result<Vec<Vec<Node>>> {
-        let Trace { proto, addr, probes, limit, expiry } = trace;
+        let Trace {
+            proto,
+            addr,
+            probes,
+            limit,
+            expiry,
+        } = trace;
 
         let source = self.reserve(proto, addr).await?;
 
         let mut probe = source.probe()?;
-        let mut done  = false;
+        let mut done = false;
 
-        Ok(self.trace(&mut probe, probes, expiry).take_while(|result| {
-            let last = done;
-            if let Ok(nodes) = result {
-                done = nodes.iter().any(|node| {
-                    match node {
+        Ok(self
+            .trace(&mut probe, probes, expiry)
+            .take_while(|result| {
+                let last = done;
+                if let Ok(nodes) = result {
+                    done = nodes.iter().any(|node| match node {
                         Node::Node(_, ip, _, done) => *done || ip == &addr,
-                        Node::None(_)              => false,
-                    }
-                });
-            }
-            future::ready(!last)
-        }).take(limit).try_collect().await?)
+                        Node::None(_) => false,
+                    });
+                }
+                future::ready(!last)
+            })
+            .take(limit)
+            .try_collect()
+            .await?)
     }
 
     pub fn trace<'a>(
         &'a self,
-        probe:  &'a mut Probe,
-        count:  usize,
+        probe: &'a mut Probe,
+        count: usize,
         expiry: Duration,
     ) -> impl Stream<Item = Result<Vec<Node>>> + 'a {
         try_unfold((probe, 1), move |(probe, ttl)| async move {
@@ -76,8 +95,8 @@ impl Tracer {
 
     pub fn probe<'a>(
         &'a self,
-        probe:  &'a mut Probe,
-        ttl:    u8,
+        probe: &'a mut Probe,
+        ttl: u8,
         expiry: Duration,
     ) -> impl Stream<Item = Result<Node>> + 'a {
         try_unfold(probe, move |probe| async move {
@@ -88,9 +107,9 @@ impl Tracer {
             probe.increment();
 
             if let Ok(Some(Echo(addr, when, last))) = echo {
-                let rtt  = when.saturating_duration_since(sent);
+                let rtt = when.saturating_duration_since(sent);
                 let node = Node::Node(ttl, addr, rtt, last);
-                return Ok(Some((node, probe)))
+                return Ok(Some((node, probe)));
             }
 
             Ok(Some((Node::None(ttl), probe)))
@@ -106,10 +125,10 @@ impl Tracer {
         match probe {
             Probe::ICMP(ICMP::V4(_)) => self.sock4.send(probe, ttl).await,
             Probe::ICMP(ICMP::V6(_)) => self.sock6.send(probe, ttl).await,
-            Probe::TCP(TCP::V4(_))   => self.sock4.send(probe, ttl).await,
-            Probe::TCP(TCP::V6(_))   => self.sock6.send(probe, ttl).await,
-            Probe::UDP(UDP::V4(_))   => self.sock4.send(probe, ttl).await,
-            Probe::UDP(UDP::V6(_))   => self.sock6.send(probe, ttl).await,
+            Probe::TCP(TCP::V4(_)) => self.sock4.send(probe, ttl).await,
+            Probe::TCP(TCP::V6(_)) => self.sock6.send(probe, ttl).await,
+            Probe::UDP(UDP::V4(_)) => self.sock4.send(probe, ttl).await,
+            Probe::UDP(UDP::V6(_)) => self.sock6.send(probe, ttl).await,
         }
     }
 
@@ -121,6 +140,14 @@ impl Tracer {
         match dst {
             IpAddr::V4(..) => self.sock4.source(dst).await,
             IpAddr::V6(..) => self.sock6.source(dst).await,
+        }
+    }
+}
+
+impl Drop for Tracer {
+    fn drop(&mut self) {
+        if let Err(e) = self.shutdown.send(()) {
+            error!("background task shutdown failed: {}", e);
         }
     }
 }


### PR DESCRIPTION
I encountered some problems when using this crates: 
When I put the `pinger` in a task and run it in the background, the socket handle will be leaked and will not be released, and it will increase with the number of tasks created in my loop(`$ netstat -anp | grep 'program_name' | grep raw | wc -l`). After reading the code, I found that there is no exit logic in the `recv` task, and the `Arc<RawSocket>` will remain in the `recv` task until the program exits.

A snippet of code that can cause a leak:
```rust
#[tokio::main]
async fn main() {
    let mut interval = time::interval(Duration::from_secs(6));
    loop {
        interval.tick().await;
        task::spawn(async {
            if let Err(e) = ping().await {
                println!("{}", e);
            }
        });
    }
}

async fn ping() -> anyhow::Result<()> {
    let dur = Duration::from_secs(1);
    let pinger = Pinger::new(&Bind::default()).await?;
    let ping = Ping {
        addr: "114.114.114.114".parse()?,
        count: 2,
        expiry: dur,
    };

    let stream = pinger.ping(&ping).enumerate();
    pin_mut!(stream);

    let mut interval = time::interval(dur);
    while let Some((n, item)) = stream.next().await {
        interval.tick().await;
        println!("ping: {} {:?}", n, item);
    }
    Ok(())
}
```